### PR TITLE
Introduce DAO layer in backend

### DIFF
--- a/backend/Cargo.lock
+++ b/backend/Cargo.lock
@@ -716,6 +716,7 @@ dependencies = [
  "diesel_derives",
  "itoa 1.0.4",
  "pq-sys",
+ "r2d2",
 ]
 
 [[package]]
@@ -1433,6 +1434,7 @@ dependencies = [
  "dotenvy",
  "futures-util",
  "lettre",
+ "r2d2",
  "rand",
  "rust-argon2",
  "serde",
@@ -1629,6 +1631,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3fee2dce59f7a43418e3382c766554c614e06a552d53a8f07ef499ea4b332c0f"
 
 [[package]]
+name = "r2d2"
+version = "0.8.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51de85fb3fb6524929c8a2eb85e6b6d363de4e8c48f9e2c2eac4944abc181c93"
+dependencies = [
+ "log",
+ "parking_lot",
+ "scheduled-thread-pool",
+]
+
+[[package]]
 name = "rand"
 version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1749,6 +1762,15 @@ checksum = "88d6731146462ea25d9244b2ed5fd1d716d25c52e4d54aa4fb0f3c4e9854dbe2"
 dependencies = [
  "lazy_static",
  "windows-sys 0.36.1",
+]
+
+[[package]]
+name = "scheduled-thread-pool"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3cbc66816425a074528352f5789333ecff06ca41b36b0b0efdfbb29edc391a19"
+dependencies = [
+ "parking_lot",
 ]
 
 [[package]]

--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -16,7 +16,7 @@ actix-session = { version = "0.7", features = ["cookie-session"]}
 serde = { version = "1.0.140", features = ["derive"] }
 serde_json = "1.0.85"
 tera = { version = "1", default-features = false }
-diesel = { version = "2.0.0-rc.0", features = ["postgres"] }
+diesel = { version = "2.0.0-rc.0", features = ["postgres", "r2d2"] }
 dotenvy = "0.15"
 rust-argon2 = "1.0"
 rand = "0.8.5"
@@ -26,3 +26,4 @@ strum_macros = "0.24.1"
 futures-util = "0.3.25"
 csv = "1.1.6"
 chrono = "0.4.23"
+r2d2 = "0.8.10"

--- a/backend/src/app_config.rs
+++ b/backend/src/app_config.rs
@@ -12,6 +12,10 @@ pub fn routes(cfg: &mut web::ServiceConfig) {
             .service(web::resource("/api/admin/login").route(web::post().to(admin::check_password)))
             .service(web::resource("/api/admin/logout").route(web::post().to(admin::logout)))
             .service(
+                web::resource("/api/admin/change_password")
+                    .route(web::put().to(admin::change_password)),
+            )
+            .service(
                 web::resource("/api/admin/payment/{runner_id}")
                     .route(web::post().to(admin::modify_payment_status)),
             )

--- a/backend/src/dao/mod.rs
+++ b/backend/src/dao/mod.rs
@@ -1,0 +1,1 @@
+pub mod users;

--- a/backend/src/dao/users.rs
+++ b/backend/src/dao/users.rs
@@ -1,15 +1,36 @@
 use crate::models::users::User;
 use crate::schema::users::dsl::users;
 use crate::schema::users::username;
+use crate::DbPool;
 use diesel::prelude::*;
-use diesel::{PgConnection, RunQueryDsl, TextExpressionMethods};
+use diesel::{RunQueryDsl, TextExpressionMethods};
 
-pub fn fetch_user(connection: &mut PgConnection, user_name: String) -> User {
-    let database_result = users
-        .filter(username.like(user_name))
-        .first::<User>(connection);
-    return match database_result {
-        Ok(user) => user,
-        Err(_) => User::default(),
-    };
+#[derive(Clone)]
+pub struct Dao {
+    pool: DbPool,
+}
+
+pub trait UserDAOTrait {
+    fn new(pool: DbPool) -> Dao;
+    fn fetch_user(&self, user_name: String) -> User;
+}
+
+impl UserDAOTrait for Dao {
+    fn new(pool: DbPool) -> Dao {
+        Dao { pool: pool }
+    }
+
+    fn fetch_user(&self, user_name: String) -> User {
+        let connection = &mut self
+            .pool
+            .get()
+            .expect("couldn't get db connection from pool");
+        let database_result = users
+            .filter(username.like(user_name))
+            .first::<User>(connection);
+        return match database_result {
+            Ok(user) => user,
+            Err(_) => User::default(),
+        };
+    }
 }

--- a/backend/src/dao/users.rs
+++ b/backend/src/dao/users.rs
@@ -1,0 +1,15 @@
+use crate::models::users::User;
+use crate::schema::users::dsl::users;
+use crate::schema::users::username;
+use diesel::prelude::*;
+use diesel::{PgConnection, RunQueryDsl, TextExpressionMethods};
+
+pub fn fetch_user(connection: &mut PgConnection, user_name: String) -> User {
+    let database_result = users
+        .filter(username.like(user_name))
+        .first::<User>(connection);
+    return match database_result {
+        Ok(user) => user,
+        Err(_) => User::default(),
+    };
+}

--- a/backend/src/handlers/admin.rs
+++ b/backend/src/handlers/admin.rs
@@ -4,16 +4,14 @@ use crate::models::runner::{create_verification_code, Runner};
 use crate::models::shipping::NewShipping;
 use crate::models::users::{LoginData, LoginResponse};
 use crate::services::email::send_payment_confirmation;
-use crate::{
-    establish_connection, insert_rejected_transaction, insert_shipping, is_eu_country,
-    retrieve_donation_by_reason_for_payment, retrieve_runner_by_id, retrieve_shipping_by_runner_id,
-};
+use crate::{DbPool, establish_connection, insert_rejected_transaction, insert_shipping, is_eu_country, retrieve_donation_by_reason_for_payment, retrieve_runner_by_id, retrieve_shipping_by_runner_id};
 use actix_identity::Identity;
 use actix_web::http::StatusCode;
-use actix_web::web::{self, Json};
+use actix_web::web::{self, Data, Json};
 use actix_web::{Error, HttpMessage, HttpRequest, HttpResponse};
 use chrono::NaiveDate;
 use diesel::prelude::*;
+use diesel::row::NamedRow;
 use futures_util::stream::StreamExt as _;
 use serde::{Deserialize, Serialize};
 
@@ -108,8 +106,9 @@ pub struct RunnerListResponse {
 pub async fn check_password(
     request: HttpRequest,
     login_data: Json<LoginData>,
+    pool: Data<DbPool>
 ) -> Result<HttpResponse, Error> {
-    let connection = &mut establish_connection();
+    let connection = &mut pool.get().expect("couldn't get db connection from pool");
     let user = fetch_user(connection, login_data.username.to_string());
     if user.eq(&login_data.into_inner()) {
         let response = LoginResponse::from(&user);

--- a/backend/src/handlers/admin.rs
+++ b/backend/src/handlers/admin.rs
@@ -548,13 +548,11 @@ pub async fn get_rejected_transactions(_: Identity) -> Result<HttpResponse, Erro
 
 #[cfg(test)]
 mod tests {
-    use crate::handlers::admin::check_password;
-    use crate::models::users::LoginData;
     use crate::{
         establish_connection, insert_rejected_transaction,
         models::rejected_transaction::NewRejectedTransaction,
     };
-    use actix_web::{http, test, web};
+    use actix_web::{test};
 
     use super::filter_rfp;
 
@@ -581,61 +579,4 @@ mod tests {
         let inserted_transaction = insert_rejected_transaction(conn, new_transaction);
         assert_eq!(inserted_transaction.iban, "DE87876876876");
     }
-
-    #[test]
-    async fn unit_test_wrong_empty_user() {
-        let login_data = web::Json(LoginData {
-            username: "".to_string(),
-            password: "".to_string(),
-        });
-        let req = test::TestRequest::default().to_http_request();
-        let result = check_password(req, login_data).await.unwrap();
-        assert_eq!(result.status(), http::StatusCode::FORBIDDEN);
-    }
-
-    #[test]
-    async fn unit_test_wrong_password() {
-        let login_data = web::Json(LoginData {
-            username: "admin".to_string(),
-            password: "wrongpassword".to_string(),
-        });
-        let req = test::TestRequest::default().to_http_request();
-        let result = check_password(req, login_data).await.unwrap();
-        assert_eq!(result.status(), http::StatusCode::FORBIDDEN);
-    }
-
-    /*
-    // FIXME: disabled as the test is incomplete
-    #[test]
-    async fn unit_test_new_user_password() {
-        let conn = &mut establish_connection();
-        conn.begin_test_transaction()
-            .expect("Failed to start test transaction");
-        let hashed_password = hash_password(String::from("testpassword"));
-        let new_user = (
-            username.eq("testuser"),
-            role.eq("nonadmin"),
-            password_hash.eq(hashed_password),
-        );
-        let rows_inserted = diesel::insert_into(schema::users::table)
-            .values(&new_user)
-            .execute(conn);
-        assert_eq!(rows_inserted, Ok(1));
-
-        let login_data = web::Json(LoginData {
-            username: "testuser".to_string(),
-            password: "testpassword".to_string(),
-        });
-        let req = test::TestRequest::default().to_http_request();
-        // FIXME: need injection of connection to check_password to be in the same transaction
-        // TODO: also need to mock Identity/login
-        let result = check_password(req, login_data).await.unwrap();
-        assert_eq!(result.status(), http::StatusCode::OK);
-    }
-
-    fn hash_password(password: String) -> String {
-        let config = argon2::Config::default();
-        argon2::hash_encoded(password.as_bytes(), b"cmFuZG9tc2FsdA", &config).unwrap()
-    }
-    */
 }

--- a/backend/src/handlers/admin.rs
+++ b/backend/src/handlers/admin.rs
@@ -4,14 +4,16 @@ use crate::models::runner::{create_verification_code, Runner};
 use crate::models::shipping::NewShipping;
 use crate::models::users::{LoginData, LoginResponse};
 use crate::services::email::send_payment_confirmation;
-use crate::{DbPool, establish_connection, insert_rejected_transaction, insert_shipping, is_eu_country, retrieve_donation_by_reason_for_payment, retrieve_runner_by_id, retrieve_shipping_by_runner_id};
+use crate::{
+    establish_connection, insert_rejected_transaction, insert_shipping, is_eu_country,
+    retrieve_donation_by_reason_for_payment, retrieve_runner_by_id, retrieve_shipping_by_runner_id,
+};
 use actix_identity::Identity;
 use actix_web::http::StatusCode;
 use actix_web::web::{self, Data, Json};
 use actix_web::{Error, HttpMessage, HttpRequest, HttpResponse};
 use chrono::NaiveDate;
 use diesel::prelude::*;
-use diesel::row::NamedRow;
 use futures_util::stream::StreamExt as _;
 use serde::{Deserialize, Serialize};
 
@@ -106,10 +108,9 @@ pub struct RunnerListResponse {
 pub async fn check_password(
     request: HttpRequest,
     login_data: Json<LoginData>,
-    pool: Data<DbPool>
+    dao: Data<Dao>,
 ) -> Result<HttpResponse, Error> {
-    let connection = &mut pool.get().expect("couldn't get db connection from pool");
-    let user = fetch_user(connection, login_data.username.to_string());
+    let user = dao.fetch_user(login_data.username.to_string());
     if user.eq(&login_data.into_inner()) {
         let response = LoginResponse::from(&user);
         let json = serde_json::to_string(&response)?;

--- a/backend/src/lib.rs
+++ b/backend/src/lib.rs
@@ -18,9 +18,13 @@ pub mod models;
 pub mod schema;
 pub mod services;
 
+use diesel::r2d2::ConnectionManager;
+type DbPool = r2d2::Pool<ConnectionManager<PgConnection>>;
+
 pub fn establish_connection() -> PgConnection {
     dotenv().ok();
 
+    // FIXME: use the connection pool from the application instead
     let database_url = env::var("DATABASE_URL").expect("DATABASE_URL must be set");
     PgConnection::establish(&database_url).unwrap()
 }

--- a/backend/src/lib.rs
+++ b/backend/src/lib.rs
@@ -12,6 +12,7 @@ use self::models::shipping::{NewShipping, Shipping};
 pub mod app_config;
 pub mod builders;
 pub mod constants;
+pub mod dao;
 pub mod handlers;
 pub mod models;
 pub mod schema;

--- a/backend/src/models/users.rs
+++ b/backend/src/models/users.rs
@@ -35,6 +35,12 @@ pub struct LoginData {
     pub password: String,
 }
 
+#[derive(Deserialize)]
+pub struct PasswordChangeData {
+    pub old_password: String,
+    pub new_password: String,
+}
+
 #[derive(Serialize)]
 pub struct LoginResponse {
     pub username: String,

--- a/frontend/pace-ui/apis/api.ts
+++ b/frontend/pace-ui/apis/api.ts
@@ -59,7 +59,11 @@ export async function getAllRejectedTransactions() {
 
 export async function savePassword(data: { oldPassword?: string; newPassword?: string }): Promise<AxiosPromise> {
   console.log(`PUT request with new password`);
-  return axios.put(`${process.env.NEXT_PUBLIC_API_URL}/api/admin/change_password`, data, {
+  return axios.put(`${process.env.NEXT_PUBLIC_API_URL}/api/admin/change_password`, {
+    // make it Rust-y
+    old_password: data.oldPassword,
+    new_password: data.newPassword,
+  }, {
     headers: { 'content-type': 'application/json' }
   });
 }


### PR DESCRIPTION
Mostly for mockability in handler tests so that we don't need the database connection (which is not available on the test pipeline).

- [ ] mock Dao in tests in admin.rs